### PR TITLE
renovate: Add common config for all repos

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Onboarding preset for use with Luno's repos",
+  "extends": [
+    "config:base"
+  ],
+  "branchConcurrentLimit": 3,
+  "labels":["Bot::Renovate"],
+  "semanticCommits":  "disabled",
+  "commitMessagePrefix": "renovate:"
+}


### PR DESCRIPTION
### Added
- Renovate config for all repos, which they can inherit from, and extend (see usage in https://github.com/luno/luno-go/pull/123)