### PR TITLE
renovate: Update base config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -8,4 +8,11 @@
   "labels":["Bot::Renovate"],
   "semanticCommits":  "disabled",
   "commitMessagePrefix": "renovate:"
+  "reviewers": [
+    "echarrod"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy",
+    "gomodUpdateImportPaths"
+  ]
 }


### PR DESCRIPTION
### Changed
- base config, so we don't even have to write other configs to extend it
- Previously was going to extend this (e,g, https://github.com/luno/luno-go/edit/main/renovate.json), and add go-specific options, but would much rather just have a single config, and not have to maintain/update all of the others