### PR TITLE
renovate: Auto-merge Luno repos

### DIFF
--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -54,6 +54,22 @@
       enabled: true,
     },
     {
+      description: 'Auto-merge Luno dependencies',
+      autoMerge: true,
+      matchPackagePatterns: [
+        '^github.com/luno/.*',
+      ],
+      matchManagers: [
+        'gomod',
+      ],
+      // Only auto-merge patch and digest updates for Luno dependencies
+      matchUpdateTypes: [
+        'patch',
+        'digest',
+      ],
+      enabled: true,
+    },
+    {
       matchManagers: [
         'gomod',
       ],

--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -31,38 +31,40 @@
       enabled: false,
     },
     {
-      description: 'Auto-merge package-lock and GitHub actions',
       autoMerge: true,
-      addLabels: [
-        'Auto-merge',
-      ],
       // Don't auto-merge for packages < 1.0.0, as these can make breaking changes too, see https://semver.org/
       matchCurrentVersion: '!/^v?0/',
       // Rebase before auto-merging, to match our repo requirements.
       rebaseWhen: 'behind-base-branch',
-      matchPackagePatterns: [
-        '^github-actions.*',
-        '^package-lock',
+      autoMergePattern: '^renovate:\\s?(minor|digest)\\s?(\\(|$)',
+      autoMergePackagePatterns: [
+        {
+          matchPackageNames: [
+            '^github-actions.*'
+          ],
+          enabled: true
+        },
+        {
+          matchPackageNames: [
+            '^package-lock'
+          ],
+          enabled: true
+        },
+        {
+          matchManagers: [
+            'gomod'
+          ],
+          // Don't auto-merge for major or minor updates.
+          matchUpdateTypes: [
+            'patch',
+            'digest'
+          ],
+          enabled: true
+        }
       ],
-      enabled: true,
-
-    },
-    {
-      description: 'Auto-merge patch + digest gomod updates',
-      autoMerge: true,
       addLabels: [
         'Auto-merge',
-      ],
-      matchManagers: [
-        'gomod',
-      ],
-      matchCurrentVersion: '!/^v?0/',
-      // Don't auto-merge for major or minor updates.
-      matchUpdateTypes: [
-        'patch',
-        'digest',
-      ],
-      enabled: true,
+      ]
     }
   ],
 }

--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -31,57 +31,47 @@
       enabled: false,
     },
     {
-      description: 'Auto-merge under specific scenarios',
+      description: 'Auto-merge package-lock and GitHub actions',
       autoMerge: true,
+      rebaseWhen: 'behind-base-branch',
+      addLabels: [
+        'Auto-merge',
+      ],
       // Don't auto-merge for packages < 1.0.0, as these can make breaking changes too, see https://semver.org/
       matchCurrentVersion: '!/^v?0/',
-      // Rebase before auto-merging, to match our repo requirements.
+      matchPackagePatterns: [
+        '^github-actions.*',
+        '^package-lock'
+      ]
+    },
+    {
+      description: 'Auto-merge patch + digest gomod updates',
+      autoMerge: true,
       rebaseWhen: 'behind-base-branch',
-      autoMergePattern: '^renovate:\\s?(minor|digest)\\s?(\\(|$)',
-      autoMergePackagePatterns: [
-        {
-          matchPackageNames: [
-            '^github-actions.*'
-          ],
-          enabled: true
-        },
-        {
-          matchPackageNames: [
-            '^package-lock'
-          ],
-          enabled: true
+      addLabels: [
+        'Auto-merge',
       ],
-      enabled: true,
+      matchManagers: [
+        'gomod',
+      ],
+      matchUpdateTypes: [
+        'patch',
+        'digest',
+      ],
     },
     {
       description: 'Auto-merge Luno dependencies',
       autoMerge: true,
+      rebaseWhen: 'behind-base-branch',
       matchPackagePatterns: [
         '^github.com/luno/.*',
       ],
+      addLabels: [
+        'Auto-merge',
+      ],
       matchManagers: [
         'gomod',
       ],
-      // Only auto-merge patch and digest updates for Luno dependencies
-      matchUpdateTypes: [
-        'patch',
-        'digest',
-      ],
-      enabled: true,
     },
-    {
-      matchManagers: [
-        'gomod',
-      ],
-      // Don't auto-merge for major or minor updates.
-      matchUpdateTypes: [
-        'patch',
-        'digest',
-      ],
-      enabled: true,
-    }
-  ],
-  addLabels: [
-    'Auto-merge',
   ],
 }

--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -31,6 +31,7 @@
       enabled: false,
     },
     {
+      description: 'Auto-merge under specific scenarios',
       autoMerge: true,
       // Don't auto-merge for packages < 1.0.0, as these can make breaking changes too, see https://semver.org/
       matchCurrentVersion: '!/^v?0/',
@@ -49,22 +50,22 @@
             '^package-lock'
           ],
           enabled: true
-        },
-        {
-          matchManagers: [
-            'gomod'
-          ],
-          // Don't auto-merge for major or minor updates.
-          matchUpdateTypes: [
-            'patch',
-            'digest'
-          ],
-          enabled: true
-        }
       ],
-      addLabels: [
-        'Auto-merge',
-      ]
+      enabled: true,
+    },
+    {
+      matchManagers: [
+        'gomod',
+      ],
+      // Don't auto-merge for major or minor updates.
+      matchUpdateTypes: [
+        'patch',
+        'digest',
+      ],
+      enabled: true,
     }
+  ],
+  addLabels: [
+    'Auto-merge',
   ],
 }


### PR DESCRIPTION
### Added
- Rule so Renovate merges Luno updates automatically (want to wait til we're OK with 1.24 for all repos, since Jettison has already updated)
- We have "CI checks must pass" for all repos in a ruleset, so should never merge if CI fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Streamlined our automated dependency update process by refining auto-merge rules.
  - Introduced new conditions to automatically merge specific Luno dependency updates.
  - Enhanced tracking by adding a dedicated label for auto-merged changes. 
  - Updated auto-merge rules to include a new rebase condition for improved clarity and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->