### PR TITLE
renovate: add automerge for some scenarios

### DIFF
--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -19,20 +19,52 @@
   ],
   packageRules: [
     {
-      "packageRules": [
-        {
-          "description": 'Opt-out minimum Go version updates: https://github.com/renovatebot/renovate/issues/16715',
-          "matchManagers": [
-            'gomod',
-          ],
-          // We don't want to update the minimum Go version, this isn't _all_ Go updates,
-          // it's updates of type "golang" (i.e. Go version).
-          "matchDepTypes": [
-            'golang',
-          ],
-          "enabled": false,
-        },
+      "description": 'Opt-out minimum Go version updates: https://github.com/renovatebot/renovate/issues/16715',
+      "matchManagers": [
+        'gomod',
       ],
+      // We don't want to update the minimum Go version, this isn't _all_ Go updates,
+      // it's updates of type "golang" (i.e. Go version).
+      "matchDepTypes": [
+        'golang',
+      ],
+      "enabled": false,
     },
+    {
+      "autoMerge": true,
+      // Don't auto-merge for packages < 1.0.0, as these can make breaking changes too, see https://semver.org/
+      matchCurrentVersion: '!/^v?0/',
+      // Rebase before auto-merging, to match our repo requirements.
+      rebaseWhen: 'behind-base-branch',
+      "autoMergePattern": "^renovate:\\s?(minor|digest)\\s?(\\(|$)",
+      "autoMergePackagePatterns": [
+        {
+          "matchPackageNames": [
+            "^github-actions.*"
+          ],
+          "enabled": true
+        },
+        {
+          "matchPackageNames": [
+            "^package-lock"
+          ],
+          "enabled": true
+        },
+        {
+          "matchManagers": [
+            "gomod"
+          ],
+          // Don't auto-merge for major or minor updates.
+          "matchUpdateTypes": [
+            "patch",
+            "digest"
+          ],
+          "enabled": true
+        }
+      ],
+      addLabels: [
+        'Auto-merge',
+      ]
+    }
   ],
 }

--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -19,52 +19,43 @@
   ],
   packageRules: [
     {
-      "description": 'Opt-out minimum Go version updates: https://github.com/renovatebot/renovate/issues/16715',
-      "matchManagers": [
+      description: 'Opt-out minimum Go version updates: https://github.com/renovatebot/renovate/issues/16715',
+      matchManagers: [
         'gomod',
       ],
       // We don't want to update the minimum Go version, this isn't _all_ Go updates,
       // it's updates of type "golang" (i.e. Go version).
-      "matchDepTypes": [
+      matchDepTypes: [
         'golang',
       ],
-      "enabled": false,
+      enabled: false,
     },
     {
-      "autoMerge": true,
+      description: 'Auto-merge under specific scenarios',
+      autoMerge: true,
       // Don't auto-merge for packages < 1.0.0, as these can make breaking changes too, see https://semver.org/
       matchCurrentVersion: '!/^v?0/',
       // Rebase before auto-merging, to match our repo requirements.
       rebaseWhen: 'behind-base-branch',
-      "autoMergePattern": "^renovate:\\s?(minor|digest)\\s?(\\(|$)",
-      "autoMergePackagePatterns": [
-        {
-          "matchPackageNames": [
-            "^github-actions.*"
-          ],
-          "enabled": true
-        },
-        {
-          "matchPackageNames": [
-            "^package-lock"
-          ],
-          "enabled": true
-        },
-        {
-          "matchManagers": [
-            "gomod"
-          ],
-          // Don't auto-merge for major or minor updates.
-          "matchUpdateTypes": [
-            "patch",
-            "digest"
-          ],
-          "enabled": true
-        }
+      matchPackagePatterns: [
+        '^github-actions.*',
+        '^package-lock',
       ],
-      addLabels: [
-        'Auto-merge',
-      ]
+      enabled: true,
+    },
+    {
+      matchManagers: [
+        'gomod',
+      ],
+      // Don't auto-merge for major or minor updates.
+      matchUpdateTypes: [
+        'patch',
+        'digest',
+      ],
+      enabled: true,
     }
+  ],
+  addLabels: [
+    'Auto-merge',
   ],
 }

--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -31,8 +31,11 @@
       enabled: false,
     },
     {
-      description: 'Auto-merge under specific scenarios',
+      description: 'Auto-merge package-lock and GitHub actions',
       autoMerge: true,
+      addLabels: [
+        'Auto-merge',
+      ],
       // Don't auto-merge for packages < 1.0.0, as these can make breaking changes too, see https://semver.org/
       matchCurrentVersion: '!/^v?0/',
       // Rebase before auto-merging, to match our repo requirements.
@@ -42,11 +45,18 @@
         '^package-lock',
       ],
       enabled: true,
+
     },
     {
+      description: 'Auto-merge patch + digest gomod updates',
+      autoMerge: true,
+      addLabels: [
+        'Auto-merge',
+      ],
       matchManagers: [
         'gomod',
       ],
+      matchCurrentVersion: '!/^v?0/',
       // Don't auto-merge for major or minor updates.
       matchUpdateTypes: [
         'patch',
@@ -54,8 +64,5 @@
       ],
       enabled: true,
     }
-  ],
-  addLabels: [
-    'Auto-merge',
   ],
 }


### PR DESCRIPTION
### Changed
- Enable auto-merge for MRs which:
  - Are NOT pre 1.0.0 AND either:
    - Are patch/digest gomod updates (not minor/major) 
    - Are GitHub actions or package-lock updates

### Fixed
- Fix double nested Go update package rule

Will disable auto-MR creation whilst we test this