### PR TITLE
github/workflows: Add CoPilot inactive reminder

### DIFF
--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -85,7 +85,8 @@ jobs:
               
               echo "✅ Revoked Copilot seat for user $LOGIN"
               
-            elif [ "$REFERENCE_DATE" -lt "$REMINDER_THRESHOLD" ] && [ "$EXISTING_ISSUES" = "[]" ]; then
+            elif [ "$REFERENCE_DATE" -lt "$REMINDER_THRESHOLD" ] && \
+                 [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -eq 0 ]; then
               # 14+ days inactive - send reminder
               echo "⚠️  User $LOGIN has been inactive for 14+ days ($ACTIVITY_STATUS) - creating reminder issue"
 

--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -41,7 +41,7 @@ jobs:
             CREATED_AT=$(echo "$seat" | jq -r '.created_at')
 
             # List all open issues with label 'copilot-reminder' for this user
-            EXISTING_ISSUES=$(gh issue list --repo ${{ github.repository }} --assignee $LOGIN --label 'copilot-reminder' --json id)
+            EXISTING_ISSUES=$(gh issue list --repo ${{ github.repository }} --assignee $LOGIN --label 'copilot-reminder' --json number)
 
             # Get last activity date and convert dates to seconds since epoch for comparison
             if [ "$LAST_ACTIVITY" = "null" ]; then

--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -99,7 +99,8 @@ jobs:
               
               echo "✅ Created reminder issue: $NEW_ISSUE_URL"
               
-            elif [ "$REFERENCE_DATE" -ge "$REMINDER_THRESHOLD" ] && [ "$EXISTING_ISSUES" != "[]" ]; then
+            elif [ "$REFERENCE_DATE" -ge "$REMINDER_THRESHOLD" ] && \
+                 [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -gt 0 ]; then
               # User became active again - close any open reminder issues
               echo "🎉 User $LOGIN became active again ($ACTIVITY_STATUS) - closing reminder issues"
               
@@ -110,7 +111,7 @@ jobs:
                 echo "✅ Closed issue #$issue_number"
               done
             else
-              if [ "$EXISTING_ISSUES" != "[]" ]; then
+              if [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -gt 0 ]; then
                 echo "ℹ️  User $LOGIN still has an open reminder issue ($ACTIVITY_STATUS)"
               else
                 echo "✅ User $LOGIN is active ($ACTIVITY_STATUS)"

--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -1,0 +1,130 @@
+# GitHub Copilot Inactive User Reminder Workflow
+# This workflow identifies users who haven't used their Copilot license and creates reminder issues
+
+name: Remind inactive users about GitHub Copilot license
+
+on:
+  # Run on demand (enables 'Run workflow' button on the Actions tab)
+  workflow_dispatch:
+  # Run the workflow every day at 9am UTC (daily schedule)
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  check-inactive-users:
+    runs-on: ubuntu-latest
+
+    # Modify the default permissions granted to GITHUB_TOKEN
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Check last GitHub Copilot activity
+        id: check-last-activity
+        run: |
+          echo "🔍 Checking Copilot license usage for Luno organization..."
+          
+          # List all GitHub Copilot seat assignments for the organization
+          RESPONSE=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -H "Authorization: Bearer ${{ secrets.COPILOT_UPDATE_TOKEN }}" \
+            /orgs/luno/copilot/billing/seats)
+          
+          echo "📊 Found $(echo "$RESPONSE" | jq '.seats | length') total Copilot licenses"
+          
+          # Parse and check each user's last_activity_at and created_at
+          echo "$RESPONSE" | jq -c '.seats[]' | while read -r seat; do
+            LOGIN=$(echo "$seat" | jq -r '.assignee.login')
+            LAST_ACTIVITY=$(echo "$seat" | jq -r '.last_activity_at')
+            CREATED_AT=$(echo "$seat" | jq -r '.created_at')
+
+            # List all open issues with label 'copilot-reminder' for this user
+            EXISTING_ISSUES=$(gh issue list --repo ${{ github.repository }} --assignee $LOGIN --label 'copilot-reminder' --json id)
+
+            # Get last activity date and convert dates to seconds since epoch for comparison
+            if [ "$LAST_ACTIVITY" = "null" ]; then
+              LAST_ACTIVITY_DATE=$(date -d "$CREATED_AT" +%s)
+              ACTIVITY_STATUS="never used (license assigned $(date -d "$CREATED_AT" '+%Y-%m-%d'))"
+              # Use creation date for never-used licenses
+              REFERENCE_DATE=$LAST_ACTIVITY_DATE
+            else
+              LAST_ACTIVITY_DATE=$(date -d "$LAST_ACTIVITY" +%s)
+              ACTIVITY_STATUS="last used $(date -d "$LAST_ACTIVITY" '+%Y-%m-%d')"
+              # Use last activity date for previously used licenses
+              REFERENCE_DATE=$LAST_ACTIVITY_DATE
+            fi
+            
+            # Calculate threshold dates
+            REMINDER_THRESHOLD=$(date -d "14 days ago" +%s)
+            REVOCATION_THRESHOLD=$(date -d "30 days ago" +%s)
+
+            # Handle different stages based on inactivity duration
+            if [ "$REFERENCE_DATE" -lt "$REVOCATION_THRESHOLD" ]; then
+              # 30+ days inactive - revoke the seat
+              echo "🚨 User $LOGIN has been inactive for 30+ days ($ACTIVITY_STATUS) - revoking seat"
+              
+              # Remove the user from Copilot
+              gh api \
+                -X DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -H "Authorization: Bearer ${{ secrets.COPILOT_UPDATE_TOKEN }}" \
+                "/orgs/luno/copilot/billing/seats/$LOGIN"
+              
+              # Close any existing reminder issues with revocation notice
+              if [ "$EXISTING_ISSUES" != "[]" ]; then
+                echo "$EXISTING_ISSUES" | jq -r '.[].number' | while read -r issue_number; do
+                  gh issue close $issue_number \
+                    --repo ${{ github.repository }} \
+                    --comment "🚨 This GitHub Copilot license has been revoked due to 30 days of inactivity. If you need access again, please reach out to your team lead."
+                  echo "✅ Closed issue #$issue_number with revocation notice"
+                done
+              fi
+              
+              echo "✅ Revoked Copilot seat for user $LOGIN"
+              
+            elif [ "$REFERENCE_DATE" -lt "$REMINDER_THRESHOLD" ] && [ "$EXISTING_ISSUES" = "[]" ]; then
+              # 14+ days inactive - send reminder
+              echo "⚠️  User $LOGIN has been inactive for 14+ days ($ACTIVITY_STATUS) - creating reminder issue"
+
+              NEW_ISSUE_URL=$(gh issue create \
+                --title "Reminder about your GitHub Copilot license" \
+                --body "${{ vars.COPILOT_REMINDER_MESSAGE }}" \
+                --repo ${{ github.repository }} \
+                --assignee $LOGIN \
+                --label 'copilot-reminder')
+              
+              echo "✅ Created reminder issue: $NEW_ISSUE_URL"
+              
+            elif [ "$REFERENCE_DATE" -ge "$REMINDER_THRESHOLD" ] && [ "$EXISTING_ISSUES" != "[]" ]; then
+              # User became active again - close any open reminder issues
+              echo "🎉 User $LOGIN became active again ($ACTIVITY_STATUS) - closing reminder issues"
+              
+              echo "$EXISTING_ISSUES" | jq -r '.[].number' | while read -r issue_number; do
+                gh issue close $issue_number \
+                  --repo ${{ github.repository }} \
+                  --comment "🎉 Great! This user is now actively using GitHub Copilot. Closing this reminder automatically."
+                echo "✅ Closed issue #$issue_number"
+              done
+            else
+              if [ "$EXISTING_ISSUES" != "[]" ]; then
+                echo "ℹ️  User $LOGIN still has an open reminder issue ($ACTIVITY_STATUS)"
+              else
+                echo "✅ User $LOGIN is active ($ACTIVITY_STATUS)"
+              fi
+            fi
+          done
+
+        # Set the GH_TOKEN, required for the 'gh issue' and 'gh api' commands
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_UPDATE_TOKEN }}
+
+      - name: Summary
+        run: |
+          echo "🎯 Copilot license management check completed"
+          echo "📝 Reminder issues created for users inactive 14+ days"
+          echo "🚨 Copilot seats revoked for users inactive 30+ days"
+          echo "🎉 Issues automatically closed for users who became active again"
+          echo "🔄 This workflow runs daily at 9am UTC"

--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -26,15 +26,14 @@ jobs:
           echo "🔍 Checking Copilot license usage for Luno organization..."
           
           # List all GitHub Copilot seat assignments for the organization
-          RESPONSE=$(gh api \
+          RESPONSE=$(gh api --paginate \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             -H "Authorization: Bearer ${{ secrets.COPILOT_UPDATE_TOKEN }}" \
-            /orgs/luno/copilot/billing/seats)
+            /orgs/luno/copilot/billing/seats | \
+            jq -s '{ seats: map(.seats[]) }')
           
           echo "📊 Found $(echo "$RESPONSE" | jq '.seats | length') total Copilot licenses"
-          
-          # Parse and check each user's last_activity_at and created_at
           echo "$RESPONSE" | jq -c '.seats[]' | while read -r seat; do
             LOGIN=$(echo "$seat" | jq -r '.assignee.login')
             LAST_ACTIVITY=$(echo "$seat" | jq -r '.last_activity_at')

--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -74,7 +74,7 @@ jobs:
                 "/orgs/luno/copilot/billing/seats/$LOGIN"
               
               # Close any existing reminder issues with revocation notice
-              if [ "$EXISTING_ISSUES" != "[]" ]; then
+              if [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -gt 0 ]; then
                 echo "$EXISTING_ISSUES" | jq -r '.[].number' | while read -r issue_number; do
                   gh issue close $issue_number \
                     --repo ${{ github.repository }} \

--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ The `.github` repository provides organisation-wide defaults that apply to all r
 
 ## 🤖 Automated Tools
 
-### GitHub Copilot License Management
+### GitHub Copilot Licence Management
 
-We maintain an automated system for managing GitHub Copilot licenses:
+We maintain an automated system for managing GitHub Copilot licences:
 
-- **Daily monitoring** of license usage across the organisation
+- **Daily monitoring** of licence usage across the organisation
 - **Automatic reminders** for inactive users (14-day threshold)
-- **License revocation** for prolonged inactivity (30-day threshold)
-- **Issue tracking** for license optimisation
+- **Licence revocation** for prolonged inactivity (30-day threshold)
+- **Issue tracking** for licence optimisation
 
 📋 **Management Guide**: [GitHub Copilot Reminder Setup](./docs/copilot-reminder-setup.md)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Luno GitHub Configuration
+
+This repository contains organisation-level GitHub configuration and defaults for the [Luno](https://github.com/luno) organisation. It serves as our organisational profile and provides centralised automation for managing development tools and licenses.
+
+## 🏢 Organisation Profile
+
+This repository acts as our organisation's profile page, displaying:
+
+- **Organisation overview** and mission
+- **Community health files** (CODE_OF_CONDUCT, CONTRIBUTING, etc.)
+- **Default templates** for issues and pull requests
+- **Public documentation** about our development practices
+
+## 🔧 Organisation Defaults
+
+The `.github` repository provides organisation-wide defaults that apply to all repositories:
+
+- **Issue templates** - Standardised issue forms for bugs, features, and support
+- **Pull request templates** - Consistent PR descriptions and checklists
+- **Security policies** - Vulnerability disclosure and security practices
+- **Code of conduct** - Community guidelines and behavioral expectations
+- **Contributing guidelines** - How to contribute to Luno projects
+
+## 🤖 Automated Tools
+
+### GitHub Copilot License Management
+
+We maintain an automated system for managing GitHub Copilot licenses:
+
+- **Daily monitoring** of license usage across the organisation
+- **Automatic reminders** for inactive users (14-day threshold)
+- **License revocation** for prolonged inactivity (30-day threshold)
+- **Issue tracking** for license optimisation
+
+📋 **Management Guide**: [GitHub Copilot Reminder Setup](./docs/copilot-reminder-setup.md)

--- a/docs/copilot-reminder-setup.md
+++ b/docs/copilot-reminder-setup.md
@@ -20,7 +20,7 @@ The system consists of several integrated components working together:
 ### Required Infrastructure
 
 - **Label**: `copilot-reminder` - Used to tag and track reminder issues
-- **Repository Secret**: `COPILOT_LICENSE_READ` - Contains personal access token with required permissions
+- **Repository Secret**: `COPILOT_UPDATE_TOKEN` - Personal access token used by the workflow
 - **Repository Variable**: `COPILOT_REMINDER_MESSAGE` - Stores the reminder message template
 - **GitHub Actions Workflow**: Automates the entire process daily
 

--- a/docs/copilot-reminder-setup.md
+++ b/docs/copilot-reminder-setup.md
@@ -1,14 +1,14 @@
-# GitHub Copilot License Management System
+# GitHub Copilot Licence Management System
 
-This document explains how the automated GitHub Copilot license management system works for the Luno organisation.
+This document explains how the automated GitHub Copilot licence management system works for the Luno organisation.
 
 ## System Overview
 
-The automated system manages GitHub Copilot licenses by:
+The automated system manages GitHub Copilot licences by:
 
-- ✅ **Daily monitoring** of Copilot license usage (every day at 9am UTC)
+- ✅ **Daily monitoring** of Copilot licence usage (every day at 9am UTC)
 - ✅ **Automatic reminders** for users who haven't used Copilot for **14+ days**
-- ✅ **License revocation** for users inactive for **30+ days**
+- ✅ **Licence revocation** for users inactive for **30+ days**
 - ✅ **Issue tracking** with assignments to inactive users
 - ✅ **Automatic issue closure** when users become active again
 - ✅ **Duplicate prevention** to avoid multiple reminders for the same user
@@ -38,11 +38,11 @@ The automated workflow operates on a daily schedule and follows this process:
 The system uses a standardised message template *stored in a repository variable*:
 
 ```markdown
-## 🤖 GitHub Copilot License Reminder
+## 🤖 GitHub Copilot Licence Reminder
 
 Hi there! 👋
 
-We noticed you haven't used your assigned license for **GitHub Copilot** and it has been inactive for a period of 14 days. Here are some resources that might help you get started:
+We noticed you haven't used your assigned licence for **GitHub Copilot** and it has been inactive for a period of 14 days. Here are some resources that might help you get started:
 
 ### 🚀 Getting Started
 * **Setup Guide**: If you haven't yet set up Copilot in your environment, see [Setting up GitHub Copilot for yourself](https://docs.github.com/en/copilot/setting-up-github-copilot/setting-up-github-copilot-for-yourself)
@@ -61,10 +61,10 @@ If you're having trouble getting started or have questions about using Copilot e
 - Ask in our internal development channels
 
 ### ⚡ Next Steps
-If you no longer need access to GitHub Copilot, please let us know in this issue. If your license remains inactive for a further 16 days (30 total), we'll revoke it to free up access for another user.
+If you no longer need access to GitHub Copilot, please let us know in this issue. If your licence remains inactive for a further 16 days (30 total), we'll revoke it to free up access for another user.
 
 ---
-*This is an automated reminder sent daily to help ensure our Copilot licenses are being used effectively.*
+*This is an automated reminder sent daily to help ensure our Copilot licences are being used effectively.*
 ```
 
 ## System Logic & Automation
@@ -74,7 +74,7 @@ If you no longer need access to GitHub Copilot, please let us know in this issue
 The system operates on a two-stage approach:
 
 - **14 days inactive**: First reminder issue created with helpful resources and 16-day warning
-- **30 days inactive**: License automatically revoked and reminder issue closed
+- **30 days inactive**: Licence automatically revoked and reminder issue closed
 - **Schedule**: Runs every day at 9am UTC via GitHub Actions
 - **Manual trigger**: Available through the "Run workflow" button
 - **Auto-closure**: Issues are automatically closed when users become active again
@@ -85,11 +85,11 @@ The system manages GitHub issues with the following behaviour:
 
 **Issue Creation (14 days inactive):**
 
-- Creates issues with title: "Reminder about your GitHub Copilot license"
+- Creates issues with title: "Reminder about your GitHub Copilot licence"
 - Assigns issues directly to the inactive user
 - Tags issues with the `copilot-reminder` label
 - Includes comprehensive setup and troubleshooting resources
-- Warns users about license revocation in 16 days
+- Warns users about licence revocation in 16 days
 
 **Duplicate Prevention:**
 
@@ -100,22 +100,22 @@ The system manages GitHub issues with the following behaviour:
 **Automatic Issue Closure:**
 
 - **When users become active**: Issues are closed with a celebratory comment
-- **When licenses are revoked**: Issues are closed with a revocation notice
+- **When licences are revoked**: Issues are closed with a revocation notice
 - Maintains a clean issue tracker with current status
 
 ## User Journey Examples
 
 ### Scenario 1: User Becomes Active
 
-- **Day 1**: User gets assigned Copilot license
-- **Day 14**: User hasn't used license → Reminder issue created with 16-day warning
+- **Day 1**: User gets assigned Copilot licence
+- **Day 14**: User hasn't used licence → Reminder issue created with 16-day warning
 - **Day 18**: User starts using Copilot → Issue automatically closed with celebration message
 
-### Scenario 2: License Revocation
+### Scenario 2: Licence Revocation
 
-- **Day 1**: User gets assigned Copilot license  
-- **Day 14**: User hasn't used license → Reminder issue created with 16-day warning
-- **Day 30**: User still hasn't used license → License revoked, issue closed with notice
+- **Day 1**: User gets assigned Copilot licence  
+- **Day 14**: User hasn't used licence → Reminder issue created with 16-day warning
+- **Day 30**: User still hasn't used licence → Licence revoked, issue closed with notice
 
 **Workflow Logs:**
 

--- a/docs/copilot-reminder-setup.md
+++ b/docs/copilot-reminder-setup.md
@@ -1,0 +1,124 @@
+# GitHub Copilot License Management System
+
+This document explains how the automated GitHub Copilot license management system works for the Luno organisation.
+
+## System Overview
+
+The automated system manages GitHub Copilot licenses by:
+
+- ✅ **Daily monitoring** of Copilot license usage (every day at 9am UTC)
+- ✅ **Automatic reminders** for users who haven't used Copilot for **14+ days**
+- ✅ **License revocation** for users inactive for **30+ days**
+- ✅ **Issue tracking** with assignments to inactive users
+- ✅ **Automatic issue closure** when users become active again
+- ✅ **Duplicate prevention** to avoid multiple reminders for the same user
+
+## System Components
+
+The system consists of several integrated components working together:
+
+### Required Infrastructure
+
+- **Label**: `copilot-reminder` - Used to tag and track reminder issues
+- **Repository Secret**: `COPILOT_LICENSE_READ` - Contains personal access token with required permissions
+- **Repository Variable**: `COPILOT_REMINDER_MESSAGE` - Stores the reminder message template
+- **GitHub Actions Workflow**: Automates the entire process daily
+
+## Workflow Process
+
+The automated workflow operates on a daily schedule and follows this process:
+
+### Daily Execution
+
+**Schedule**: Every day at 9am UTC via GitHub Actions cron schedule  
+**Manual Trigger**: Available through the "Run workflow" button in Actions tab
+
+### Reminder Message Content
+
+The system uses a standardised message template *stored in a repository variable*:
+
+```markdown
+## 🤖 GitHub Copilot License Reminder
+
+Hi there! 👋
+
+We noticed you haven't used your assigned license for **GitHub Copilot** and it has been inactive for a period of 14 days. Here are some resources that might help you get started:
+
+### 🚀 Getting Started
+* **Setup Guide**: If you haven't yet set up Copilot in your environment, see [Setting up GitHub Copilot for yourself](https://docs.github.com/en/copilot/setting-up-github-copilot/setting-up-github-copilot-for-yourself)
+* **Troubleshooting**: Having issues? Check [Troubleshooting common issues with GitHub Copilot](https://docs.github.com/en/copilot/troubleshooting-github-copilot/troubleshooting-common-issues-with-github-copilot)
+* **Luno-specific tips**: Check out the bookmarks in our #engineering-with-ai channel
+
+### 📚 Best Practices & Tips
+* **Best Practices**: Learn how to get the most out of Copilot with [Best practices for using GitHub Copilot](https://docs.github.com/en/copilot/using-github-copilot/best-practices-for-using-github-copilot)
+* **Prompt Engineering**: Improve your prompts with [Prompt engineering for GitHub Copilot](https://docs.github.com/en/copilot/using-github-copilot/prompt-engineering-for-github-copilot)
+* **Examples**: See practical examples in the [Copilot Chat Cookbook](https://docs.github.com/en/copilot/example-prompts-for-github-copilot-chat)
+
+### 💬 Need Help?
+If you're having trouble getting started or have questions about using Copilot effectively, feel free to:
+- Comment on this issue
+- Reach out to your team lead
+- Ask in our internal development channels
+
+### ⚡ Next Steps
+If you no longer need access to GitHub Copilot, please let us know in this issue. If your license remains inactive for a further 16 days (30 total), we'll revoke it to free up access for another user.
+
+---
+*This is an automated reminder sent daily to help ensure our Copilot licenses are being used effectively.*
+```
+
+## System Logic & Automation
+
+### Timing Thresholds
+
+The system operates on a two-stage approach:
+
+- **14 days inactive**: First reminder issue created with helpful resources and 16-day warning
+- **30 days inactive**: License automatically revoked and reminder issue closed
+- **Schedule**: Runs every day at 9am UTC via GitHub Actions
+- **Manual trigger**: Available through the "Run workflow" button
+- **Auto-closure**: Issues are automatically closed when users become active again
+
+### Issue Management Process
+
+The system manages GitHub issues with the following behaviour:
+
+**Issue Creation (14 days inactive):**
+
+- Creates issues with title: "Reminder about your GitHub Copilot license"
+- Assigns issues directly to the inactive user
+- Tags issues with the `copilot-reminder` label
+- Includes comprehensive setup and troubleshooting resources
+- Warns users about license revocation in 16 days
+
+**Duplicate Prevention:**
+
+- Checks for existing open issues with the `copilot-reminder` label
+- Skips users who already have an active reminder issue
+- Prevents notification spam for the same user
+
+**Automatic Issue Closure:**
+
+- **When users become active**: Issues are closed with a celebratory comment
+- **When licenses are revoked**: Issues are closed with a revocation notice
+- Maintains a clean issue tracker with current status
+
+## User Journey Examples
+
+### Scenario 1: User Becomes Active
+
+- **Day 1**: User gets assigned Copilot license
+- **Day 14**: User hasn't used license → Reminder issue created with 16-day warning
+- **Day 18**: User starts using Copilot → Issue automatically closed with celebration message
+
+### Scenario 2: License Revocation
+
+- **Day 1**: User gets assigned Copilot license  
+- **Day 14**: User hasn't used license → Reminder issue created with 16-day warning
+- **Day 30**: User still hasn't used license → License revoked, issue closed with notice
+
+**Workflow Logs:**
+
+- Detailed execution logs available in **Actions** → workflow run → job details
+- Visual indicators: ✅ (active), ⚠️ (inactive), ℹ️ (already reminded)
+- Timestamp tracking for all API calls and decisions


### PR DESCRIPTION
### Added
- CoPilot inactive reminder:
  - ✅ **Daily monitoring** of Copilot license usage (every day at 9am UTC)
  - ✅ **Automatic reminders** for users who haven't used Copilot for **14+ days**
  - ✅ **License revocation** for users inactive for **30+ days**
  - ✅ **Issue tracking** with assignments to inactive users
  - ✅ **Automatic issue closure** when users become active again
  - ✅ **Duplicate prevention** to avoid multiple reminders for the same user

Docs: https://docs.github.com/en/copilot/rolling-out-github-copilot-at-scale/assigning-licenses/reminding-inactive-users



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an automated system to monitor GitHub Copilot licence usage, send inactivity reminders, and revoke licences after extended inactivity.
- **Documentation**
	- Added a README outlining organisation-wide GitHub settings and Copilot licence management.
	- Provided detailed setup and usage instructions for the Copilot reminder system, including user journeys and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->