### PR TITLE
github/workflow: Handle 404 gracefully when trying to revoke

### DIFF
--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Check last GitHub Copilot activity
         id: check-last-activity
         run: |
+          set -euo pipefail # Enable strict error handling
+
           echo "🔍 Checking Copilot license usage for Luno organization..."
           
           # List all GitHub Copilot seat assignments for the organization
@@ -65,8 +67,9 @@ jobs:
               echo "🚨 User $LOGIN has been inactive for 30+ days ($ACTIVITY_STATUS) - revoking seat"
               
               # Remove the user from Copilot
-              set +e # Disable exit on error
-              REVOKE_OUTPUT=$(gh api \
+              # Temporarily relax exit-on-error for the DELETE call only
+              set +e
+              REVOKE_OUTPUT=$(gh api -i \
                 -X DELETE \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
@@ -77,7 +80,7 @@ jobs:
               set -e # Re-enable exit on error
 
               if [ $REVOKE_STATUS -ne 0 ]; then
-                if echo "$REVOKE_OUTPUT" | grep -q "Not Found"; then
+                if echo "$REVOKE_OUTPUT" | head -n1 | grep -q " 404 "; then
                   echo "ℹ️ User $LOGIN was already removed or not found, skipping revocation."
                 else
                   echo "🚨 Error revoking Copilot seat for user $LOGIN: $REVOKE_OUTPUT"
@@ -85,15 +88,17 @@ jobs:
                 fi
               else
                 echo "✅ Revoked Copilot seat for user $LOGIN"
-                # Close any existing reminder issues with revocation notice
-                if [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -gt 0 ]; then
-                  echo "$EXISTING_ISSUES" | jq -r '.[].number' | while read -r issue_number; do
-                    gh issue close $issue_number \
-                      --repo ${{ github.repository }} \
-                      --comment "🚨 This GitHub Copilot license has been revoked due to 30 days of inactivity. If you need access again, please reach out to your team lead."
-                    echo "✅ Closed issue #$issue_number with revocation notice"
-                  done
-                fi
+              fi
+              
+              # Close stale reminder issues regardless of whether the seat
+              # was just revoked or had already been revoked earlier
+              if [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -gt 0 ]; then
+                echo "$EXISTING_ISSUES" | jq -r '.[].number' | while read -r issue_number; do
+                  gh issue close $issue_number \
+                    --repo ${{ github.repository }} \
+                    --comment "🚨 This GitHub Copilot license has been revoked due to 30 days of inactivity. If you need access again, please reach out to your team lead."
+                  echo "✅ Closed issue #$issue_number with revocation notice"
+                done
               fi
               
             elif [ "$REFERENCE_DATE" -lt "$REMINDER_THRESHOLD" ] && \
@@ -132,7 +137,7 @@ jobs:
 
         # Set the GH_TOKEN, required for the 'gh issue' and 'gh api' commands
         env:
-          GH_TOKEN: ${{ secrets.COPILOT_UPDATE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |

--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -80,7 +80,8 @@ jobs:
               set -e # Re-enable exit on error
 
               if [ $REVOKE_STATUS -ne 0 ]; then
-                if echo "$REVOKE_OUTPUT" | head -n1 | grep -q " 404 "; then
+                STATUS_CODE=$(echo "$REVOKE_OUTPUT" | head -n1 | awk '{print $2}')
+                if [ "$STATUS_CODE" = "404" ]; then
                   echo "ℹ️ User $LOGIN was already removed or not found, skipping revocation."
                 else
                   echo "🚨 Error revoking Copilot seat for user $LOGIN: $REVOKE_OUTPUT"

--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -65,25 +65,36 @@ jobs:
               echo "🚨 User $LOGIN has been inactive for 30+ days ($ACTIVITY_STATUS) - revoking seat"
               
               # Remove the user from Copilot
-              gh api \
+              set +e # Disable exit on error
+              REVOKE_OUTPUT=$(gh api \
                 -X DELETE \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 -H "Authorization: Bearer ${{ secrets.COPILOT_UPDATE_TOKEN }}" \
                 "/orgs/luno/copilot/billing/selected_users" \
-                -f selected_usernames[]="$LOGIN"
-              
-              # Close any existing reminder issues with revocation notice
-              if [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -gt 0 ]; then
-                echo "$EXISTING_ISSUES" | jq -r '.[].number' | while read -r issue_number; do
-                  gh issue close $issue_number \
-                    --repo ${{ github.repository }} \
-                    --comment "🚨 This GitHub Copilot license has been revoked due to 30 days of inactivity. If you need access again, please reach out to your team lead."
-                  echo "✅ Closed issue #$issue_number with revocation notice"
-                done
+                -f selected_usernames[]="$LOGIN" 2>&1) # Redirect stderr to stdout
+              REVOKE_STATUS=$?
+              set -e # Re-enable exit on error
+
+              if [ $REVOKE_STATUS -ne 0 ]; then
+                if echo "$REVOKE_OUTPUT" | grep -q "Not Found"; then
+                  echo "ℹ️ User $LOGIN was already removed or not found, skipping revocation."
+                else
+                  echo "🚨 Error revoking Copilot seat for user $LOGIN: $REVOKE_OUTPUT"
+                  exit 1 # Exit with error for other issues
+                fi
+              else
+                echo "✅ Revoked Copilot seat for user $LOGIN"
+                # Close any existing reminder issues with revocation notice
+                if [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -gt 0 ]; then
+                  echo "$EXISTING_ISSUES" | jq -r '.[].number' | while read -r issue_number; do
+                    gh issue close $issue_number \
+                      --repo ${{ github.repository }} \
+                      --comment "🚨 This GitHub Copilot license has been revoked due to 30 days of inactivity. If you need access again, please reach out to your team lead."
+                    echo "✅ Closed issue #$issue_number with revocation notice"
+                  done
+                fi
               fi
-              
-              echo "✅ Revoked Copilot seat for user $LOGIN"
               
             elif [ "$REFERENCE_DATE" -lt "$REMINDER_THRESHOLD" ] && \
                  [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -eq 0 ]; then


### PR DESCRIPTION
### Changed

- Handle 404 when revoke has already been done

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved error handling and messaging in the workflow that manages GitHub Copilot seat revocation for inactive users.
  * Enhanced workflow reliability by distinguishing between users already removed and other errors, ensuring reminder issues are only closed after successful revocation.
  * Updated authentication token usage in the workflow for better security and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->