### PR TITLE
github/workflows: Update assignment to not fail if err

### DIFF
--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -112,8 +112,8 @@ jobs:
                 --title "Reminder about your GitHub Copilot license - $LOGIN" \
                 --body "${{ vars.COPILOT_REMINDER_MESSAGE }}" \
                 --repo ${{ github.repository }} \
-                --assignee $LOGIN \
-                --label 'copilot-reminder' 2>&1) # Redirect stderr to stdout
+                --label 'copilot-reminder' \
+                --assignee $LOGIN 2>&1) # Redirect stderr to stdout
               ISSUE_CREATE_STATUS=$?
               set -e # Re-enable exit on error
 


### PR DESCRIPTION
### Changed
- Update assignment to not fail if err

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the order of command-line flags in the workflow for creating reminder issues related to inactive GitHub Copilot users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->