### PR TITLE
workflows: Update CoPilot reminder to create issue after 21 days

### DIFF
--- a/.github/workflows/copilot-inactive-reminder.yml
+++ b/.github/workflows/copilot-inactive-reminder.yml
@@ -37,7 +37,7 @@ jobs:
           echo "📊 Found $(echo "$RESPONSE" | jq '.seats | length') total Copilot licenses"
 
           # Calculate threshold dates once per run for consistency
-          REMINDER_THRESHOLD=$(date -d "14 days ago" +%s)
+          REMINDER_THRESHOLD=$(date -d "21 days ago" +%s)
           REVOCATION_THRESHOLD=$(date -d "30 days ago" +%s)
 
           while read -r seat; do
@@ -115,8 +115,8 @@ jobs:
 
             elif [ "$REFERENCE_DATE" -lt "$REMINDER_THRESHOLD" ] && \
                  [ "$(echo "$EXISTING_ISSUES" | jq 'length')" -eq 0 ]; then
-              # 14+ days inactive - send reminder
-              echo "⚠️  User $LOGIN has been inactive for 14+ days ($ACTIVITY_STATUS) - creating reminder issue"
+              # 21+ days inactive - send reminder
+              echo "⚠️  User $LOGIN has been inactive for 21+ days ($ACTIVITY_STATUS) - creating reminder issue"
 
               # Try to create issue with assignee first
               set +e # Temporarily relax exit-on-error
@@ -215,7 +215,7 @@ jobs:
       - name: Summary
         run: |
           echo "🎯 Copilot license management check completed"
-          echo "📝 Reminder issues created for users inactive 14+ days"
+          echo "📝 Reminder issues created for users inactive 21+ days"
           echo "🚨 Copilot seats revoked for users inactive 30+ days"
           echo "🎉 Issues automatically closed for users who became active again"
           echo "🔄 This workflow runs daily at 9am UTC"


### PR DESCRIPTION
- Update CoPilot reminder to create issue after 21 days rather than 14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased inactivity threshold for reminder notifications from 14 days to 21 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->