### PR TITLE
renovate: Enable forkProcessing to allow default config on forks

### DIFF
--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -4,6 +4,7 @@
   extends: [
     'config:recommended',
   ],
+  includeForks: true,
   branchConcurrentLimit: 3,
   labels: [
     'Bot::Renovate',

--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -4,7 +4,7 @@
   extends: [
     'config:recommended',
   ],
-  includeForks: true,
+  forkProcessing: 'enabled',
   branchConcurrentLimit: 3,
   labels: [
     'Bot::Renovate',


### PR DESCRIPTION
## Summary
- Adds `forkProcessing: 'enabled'` to the default Renovate config to ensure it applies to forked repositories
- Resolves the issue where default config was found but did not enable forks
- Ensures our forked repos (e.g. [tengo](https://github.com/luno/tengo)) have renovate run too 
