### PR TITLE
renovate: Fix automerge config and add auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -22,7 +22,8 @@ jobs:
           # Check that PR only changes go.mod and/or go.sum
           FILES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
           for file in $FILES; do
-            if [[ "$file" != "go.mod" && "$file" != "go.sum" ]]; then
+            base=$(basename "$file")
+            if [[ "$base" != "go.mod" && "$base" != "go.sum" ]]; then
               echo "::notice::Skipping auto-approve: PR changes $file (not just go.mod/go.sum)"
               exit 0
             fi

--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -1,0 +1,48 @@
+name: Auto-approve Renovate Luno dependency updates
+
+on:
+  workflow_call:
+
+jobs:
+  auto-approve:
+    if: github.event.pull_request.user.login == 'renovate[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Verify PR qualifies for auto-approval
+        id: verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Check that PR only changes go.mod and/or go.sum
+          FILES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json files --jq '.files[].path')
+          for file in $FILES; do
+            if [[ "$file" != "go.mod" && "$file" != "go.sum" ]]; then
+              echo "::notice::Skipping auto-approve: PR changes $file (not just go.mod/go.sum)"
+              exit 0
+            fi
+          done
+
+          # Check that the PR updates a github.com/luno/ dependency
+          TITLE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title --jq '.title')
+          if ! echo "$TITLE" | grep -q 'github\.com/luno/'; then
+            echo "::notice::Skipping auto-approve: not a github.com/luno/ dependency update"
+            exit 0
+          fi
+
+          echo "should_approve=true" >> "$GITHUB_OUTPUT"
+
+      - name: Approve PR
+        if: steps.verify.outputs.should_approve == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr review "$PR_NUMBER" --repo "$REPO" --approve \
+            --body "Auto-approved: Renovate update of github.com/luno/ dependency (only go.mod/go.sum changes)"

--- a/renovate-default-config.json5
+++ b/renovate-default-config.json5
@@ -41,10 +41,10 @@
     },
     {
       description: 'Auto-merge Luno dependencies',
-      autoMerge: true,
+      automerge: true,
       rebaseWhen: 'behind-base-branch',
-      matchPackagePatterns: [
-        '!github.com/luno/**',
+      matchPackageNames: [
+        'github.com/luno/**',
       ],
       addLabels: [
         'Auto-merge',


### PR DESCRIPTION
## Summary
- Fix two bugs in the automerge package rule that prevented Luno dependency PRs from being automerged:
  - `autoMerge` → `automerge` (Renovate requires all lowercase)
  - `matchPackagePatterns: ['!github.com/luno/**']` → `matchPackageNames: ['github.com/luno/**']` (was negated, excluding Luno packages instead of matching them)
- Add a reusable workflow for auto-approving Renovate PRs that update `github.com/luno/` dependencies and only change `go.mod`/`go.sum`

## Test plan
- [ ] Merge this PR
- [ ] Add caller workflow to `luno/lu` (PR incoming)
- [ ] Verify next Renovate run picks up automerge config
- [ ] Verify auto-approve triggers on qualifying PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated approval workflow for dependency updates from Renovate
  * Updated dependency management configuration to refine package filtering rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->